### PR TITLE
Proposal for "Refactoring of Common Modules"

### DIFF
--- a/proposals/NNNN-test-scripts-common-modules-refactoring.md
+++ b/proposals/NNNN-test-scripts-common-modules-refactoring.md
@@ -1,35 +1,90 @@
-# Test Scripts - Refactoring of common mudules
+# Test Scripts - Refactoring of Common modules
 
-* Proposal: [SDL-NNNN](NNNN-testing-refactoring-common-modules.md)
+* Proposal: [SDL-NNNN](NNNN-test-scripts-common-modules-refactoring.md)
 * Author: [Dmytro Boltovskyi](https://github.com/dboltovskyi)
 * Status: **Awaiting review**
 * Impacted Platforms: [ATF]
 
 ## Introduction
 
-The main aim of this proposal is to update common modules of test scripts.
+ATF Test Scripts use a lot of commonly used functions. Such as:
+
+  - data accessors: file, database
+  - functions for tables: print, copy
+  - sequences:
+    - create mobile session
+    - register/activate mobile application
+    - perform policy table update
+  - etc.
+
+The purpose of this proposal is to clean up these common modules.
 
 ## Motivation
 
-User modules consist of commonly used functions.
+Current downsides of common modules are:
 
-Current downsides are:
- - No single standard
- - Duplicates
- - Lack of description
- - A lot of outdated or unused code
+  - There is no clear structure
+  - Lack of description for huge amount of functions
+  - There is no single standard for the functions
+  - Some functions are duplicated
+  - A lot of outdated and unused code
 
 ## Proposed solution
 
-To Do:
- - Design a standard template for common functions
- - Split all functions into two groups: Utils and Common sequences
- - Split these two huge groups between a few modules (based on functionality)
- - Update all existing test scripts
+### Leave existing modules as is
+
+By leaving all existing modules currently located in ./user_modules folder as is
+it will be possible to use all existing ATF test scripts without changes.
+
+### Design a standard template for functions
+
+Each function in common modules should follow a template. E.g.:
+
+```lua
+--[[ @jsonFileToTable: convert .json file to table
+--! @parameters:
+--! pFileName - input file name
+--! @return: table with data
+--]]
+local function jsonFileToTable(pFileName)
+  local f = io.open(pFileName, "r")
+  local content = f:read("*all")
+  f:close()
+  return json.decode(content)
+end
+```
+
+### Create new folders structure
+
+In test scripts repository create the following folders structure:
+
+```
+  ./common_modules/
+          utils/
+          sequences/
+```
+
+  - utils - folder for modules with utility functions (e.g.: data accessors, table functions, data converters, etc.)
+  - sequences - folder for modules with common sequences (e.g.: register/activate mobile application, policy update, put file, etc.)
+
+TBD: Names of the module files.
+
+### Transfer most used common functions into a new folder
+
+Most used functions needs to be transferred from existing "user_modules" to a new "common_modules" folder in appropriate module file.
+And they also need to be updated according to a new template.
+A few functions can be placed in one module file.
+
+TBD: Define module file for each function.
+
+### Follow new approach when developing new ATF test scripts
+
+  - In newly created ATF scripts use only functions from new "common_modules" folder and not from an old "user_modules" one
+  - If some utility or common sequence function doesn't exist create it in a new "common_modules" in appropriate module file using standard template
 
 ## Potential downsides
 
-Existing test scripts may need to be updated if some funtion from new common modules is required
+Existing ATF test scripts may need to be updated if some function from new common modules is required.
 
 ## Impact on existing code
 
@@ -37,5 +92,5 @@ Since new common modules is going to be implemented in a new separate folder the
 
 ## Alternatives considered
 
-No alternatives considered
+Use current approach.
 

--- a/proposals/NNNN-test-scripts-common-modules-refactoring.md
+++ b/proposals/NNNN-test-scripts-common-modules-refactoring.md
@@ -7,7 +7,7 @@
 
 ## Introduction
 
-ATF Test Scripts use a lot of commonly used functions. Such as:
+[ATF test scripts](https://github.com/smartdevicelink/sdl_atf_test_scripts/) use a lot of functions in commonly used modules, like:
 
   - data accessors: file, database
   - functions for tables: print, copy
@@ -17,7 +17,7 @@ ATF Test Scripts use a lot of commonly used functions. Such as:
     - perform policy table update
   - etc.
 
-The purpose of this proposal is to clean up these common modules.
+All these functionality are not tests artifacts but tools that tests use.
 
 ## Motivation
 
@@ -31,7 +31,9 @@ Current downsides of common modules are:
 
 ## Proposed solution
 
-### Leave existing modules as is
+The purpose of this proposal is to clean up these common modules.
+
+### Leave existing modules as is for backward compatibility
 
 By leaving all existing modules currently located in ./user_modules folder as is
 it will be possible to use all existing ATF test scripts without changes.
@@ -67,24 +69,20 @@ In test scripts repository create the following folders structure:
   - utils - folder for modules with utility functions (e.g.: data accessors, table functions, data converters, etc.)
   - sequences - folder for modules with common sequences (e.g.: register/activate mobile application, policy update, put file, etc.)
 
-TBD: Names of the module files.
-
 ### Transfer most used common functions into a new folder
 
-Most used functions needs to be transferred from existing "user_modules" to a new "common_modules" folder in appropriate module file.
-And they also need to be updated according to a new template.
+Most used functions need to be transferred from existing "user_modules" to a new "common_modules" folder in appropriate module file.
+Also they need to be updated according to a new template.
 A few functions can be placed in one module file.
-
-TBD: Define module file for each function.
 
 ### Follow new approach when developing new ATF test scripts
 
   - In newly created ATF scripts use only functions from new "common_modules" folder and not from an old "user_modules" one
-  - If some utility or common sequence function doesn't exist create it in a new "common_modules" in appropriate module file using standard template
+  - If some utility or common sequence function doesn't exist - create it in a new "common_modules" in appropriate module file using standard template
 
 ## Potential downsides
 
-Existing ATF test scripts may need to be updated if some function from new common modules is required.
+Existing ATF test scripts must be updated if some function from new common modules is required.
 
 ## Impact on existing code
 

--- a/proposals/NNNN-test-scripts-common-modules-refactoring.md
+++ b/proposals/NNNN-test-scripts-common-modules-refactoring.md
@@ -19,6 +19,8 @@
 
 All these functionality are not tests artifacts but tools that tests use.
 
+The purpose of this proposal is to clean up these common modules that everyone who create ATF test scripts be able to use them.
+
 ## Motivation
 
 Current downsides of common modules are:
@@ -31,7 +33,7 @@ Current downsides of common modules are:
 
 ## Proposed solution
 
-The purpose of this proposal is to clean up these common modules.
+In order to clean up the common modules there are following items needs to be done.
 
 ### Leave existing modules as is for backward compatibility
 

--- a/proposals/NNNN-test-scripts-common-modules-refactoring.md
+++ b/proposals/NNNN-test-scripts-common-modules-refactoring.md
@@ -19,7 +19,7 @@
 
 All these functionality are not tests artifacts but tools that tests use.
 
-The purpose of this proposal is to clean up these common modules that everyone be able to use them while creating ATF test scripts.
+The purpose of this proposal is to clean up these common modules that everyone is able to use while creating ATF test scripts.
 
 ## Motivation
 

--- a/proposals/NNNN-test-scripts-common-modules-refactoring.md
+++ b/proposals/NNNN-test-scripts-common-modules-refactoring.md
@@ -1,0 +1,41 @@
+# Test Scripts - Refactoring of common mudules
+
+* Proposal: [SDL-NNNN](NNNN-testing-refactoring-common-modules.md)
+* Author: [Dmytro Boltovskyi](https://github.com/dboltovskyi)
+* Status: **Awaiting review**
+* Impacted Platforms: [ATF]
+
+## Introduction
+
+The main aim of this proposal is to update common modules of test scripts.
+
+## Motivation
+
+User modules consist of commonly used functions.
+
+Current downsides are:
+ - No single standard
+ - Duplicates
+ - Lack of description
+ - A lot of outdated or unused code
+
+## Proposed solution
+
+To Do:
+ - Design a standard template for common functions
+ - Split all functions into two groups: Utils and Common sequences
+ - Split these two huge groups between a few modules (based on functionality)
+ - Update all existing test scripts
+
+## Potential downsides
+
+Existing test scripts may need to be updated if some funtion from new common modules is required
+
+## Impact on existing code
+
+Since new common modules is going to be implemented in a new separate folder there will be no impact on existing code.
+
+## Alternatives considered
+
+No alternatives considered
+

--- a/proposals/NNNN-test-scripts-common-modules-refactoring.md
+++ b/proposals/NNNN-test-scripts-common-modules-refactoring.md
@@ -19,7 +19,7 @@
 
 All these functionality are not tests artifacts but tools that tests use.
 
-The purpose of this proposal is to clean up these common modules that everyone who create ATF test scripts be able to use them.
+The purpose of this proposal is to clean up these common modules that everyone be able to use them while creating ATF test scripts.
 
 ## Motivation
 


### PR DESCRIPTION
Proposal for Refactoring of Common Modules

Common modules consist of commonly used functions

Current downsides:
● No single standard
● Duplicates
● Lack of description
● A lot of outdated or unused code

To Do:
● Design a standard template for common functions
● Split all functions into two groups: Utils and Common sequences
● Split these two huge groups between a few modules (based on functionality)
● Update all existing test scripts